### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: "CodeQL"
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/chriskyfung/todoist-task-reopener-worker/security/code-scanning/3](https://github.com/chriskyfung/todoist-task-reopener-worker/security/code-scanning/3)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code and runs CodeQL analysis, it only needs read access to repository contents. The best way to fix this is to add `permissions: contents: read` at the top level of the workflow (just after the `name` and before `on`), so it applies to all jobs unless overridden. This change should be made at the top of `.github/workflows/codeql.yml`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
