### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/chriskyfung/todoist-task-reopener-worker/security/code-scanning/2](https://github.com/chriskyfung/todoist-task-reopener-worker/security/code-scanning/2)

To fix the problem, you should add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. The best way to do this is to add `permissions: contents: read` at the top level of the workflow (just after the `name:` and before `on:`), which will apply to all jobs in the workflow unless overridden. This ensures the workflow adheres to the principle of least privilege and prevents accidental granting of unnecessary write permissions. No changes to the steps or jobs are needed, and no additional imports or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
