### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   update_release_draft:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v5


### PR DESCRIPTION
Potential fix for [https://github.com/chriskyfung/todoist-task-reopener-worker/security/code-scanning/1](https://github.com/chriskyfung/todoist-task-reopener-worker/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow or the specific job. Since the workflow uses the `release-drafter/release-drafter` action, the minimal required permissions are `contents: read` (to read repository contents) and `pull-requests: write` (to update release drafts as pull requests). The best way to fix this is to add the following block at the job level (under `update_release_draft:`), so it only applies to this job. Edit `.github/workflows/release-drafter.yml` and insert the `permissions` block directly under `update_release_draft:` and above `runs-on:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
