### PR TITLE
👷 build(engine): bump Node.js version to 24.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,9 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        node-version: [24.x]
     steps:
       - uses: actions/checkout@v7
 
@@ -23,7 +25,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "author": "Chris K.Y. Fung",
   "license": "MIT",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=24.18.0"
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.14.9",


### PR DESCRIPTION
- Update GitHub Actions CI to test with Node.js 24.x
- Bump engines.node in package.json to >=24.18.0