### PR TITLE
⬆️ chore(deps): upgrade todoist-api-typescript to todoist-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
-        "@doist/todoist-api-typescript": "^7.10.0",
+        "@doist/todoist-sdk": "^14.0.0",
         "tslib": "^2.8.1"
       },
       "devDependencies": {
@@ -974,19 +974,10 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
-    "node_modules/@doist/todoist-api-typescript": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/@doist/todoist-api-typescript/-/todoist-api-typescript-7.10.0.tgz",
-      "integrity": "sha512-jHDVYvyS1FjzkgzlpsBJ7Jddr/g48KyfP+nrb0xh5Uh7v/v2bljhF3+hfBO6SUaoaT3ik+bCH1hRNje39IQVXA==",
-      "deprecated": "Package renamed to @doist/todoist-sdk. Please update your dependency.",
-      "dependencies": {
-        "@doist/todoist-sdk": ">=8.0.0"
-      }
-    },
     "node_modules/@doist/todoist-sdk": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-13.0.2.tgz",
-      "integrity": "sha512-JdyI+gbqvA4oWG/QHOAE7L0iiAK/ycrO+X8avw/9H2KWs7ApSDPZEu5KpH6YENm+knW9ezcvgLSTUdEwbmvIiw==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-14.0.0.tgz",
+      "integrity": "sha512-dapFZq8Kf+1X+6rWucy22qvGIPWR+yQZzjXMXg6RPq9LXrI94hdtUbLNzEf1KMFJO2+l2BkvLygZWAP4JZANyg==",
       "license": "MIT",
       "dependencies": {
         "camelcase": "6.3.0",
@@ -4612,9 +4603,9 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
-      "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+      "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
       "license": "(MIT OR CC0-1.0)",
       "peer": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "wrangler": "^4.120.1"
   },
   "dependencies": {
-    "@doist/todoist-api-typescript": "^7.10.0",
+    "@doist/todoist-sdk": "^14.0.0",
     "tslib": "^2.8.1"
   },
   "overrides": {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,9 +1,9 @@
 import { SELF, env } from 'cloudflare:test';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { TodoistApi } from '@doist/todoist-api-typescript';
+import { TodoistApi } from '@doist/todoist-sdk';
 
 // Mock the Todoist API
-vi.mock('@doist/todoist-api-typescript', () => {
+vi.mock('@doist/todoist-sdk', () => {
   const TodoistApi = vi.fn();
   TodoistApi.prototype.getCompletedTasksByCompletionDate = vi.fn();
   TodoistApi.prototype.reopenTask = vi.fn();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { TodoistApi, Task } from '@doist/todoist-api-typescript';
+import { TodoistApi, Task } from '@doist/todoist-sdk';
 
 function timingSafeEqual(a: string, b: string): boolean {
   // While this leaks length information, it's a common practice and still


### PR DESCRIPTION
- replace deprecated todoist-api-typescript with sdk
- update @doist/todoist-sdk to v14.0.0
- update type-fest to v5.8.0