### PR TITLE
🐛 fix: pass customFetch adapter to TodoistApi to avoid SDK transport detection failure on Cloudflare Workers

### DIFF
--- a/src/adapters/http.ts
+++ b/src/adapters/http.ts
@@ -1,0 +1,29 @@
+import type { CustomFetch } from '@doist/todoist-sdk';
+
+/**
+ * A `CustomFetch` adapter that wraps Cloudflare Workers' native `fetch` into
+ * the shape expected by `@doist/todoist-sdk`.
+ *
+ * The SDK's {@link CustomFetch} type expects `headers` as a plain
+ * `Record<string, string>`, whereas Workers' native `Response` uses the
+ * `Headers` class. This adapter bridges that gap and strips the SDK's
+ * non-standard `timeout` option so it is not passed to the platform fetch.
+ */
+export const customFetch: CustomFetch = async (url, options) => {
+  const init = { ...options };
+  delete init.timeout;
+  const response = await fetch(url, init);
+  const headers: Record<string, string> = {};
+  response.headers.forEach((value, key) => {
+    headers[key] = value;
+  });
+  return {
+    ok: response.ok,
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+    text: () => response.text(),
+    json: () => response.json(),
+    arrayBuffer: () => response.arrayBuffer(),
+  };
+};

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,15 @@
 import { SELF, env } from 'cloudflare:test';
-import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type Mock,
+} from 'vitest';
 import { TodoistApi } from '@doist/todoist-sdk';
+import { customFetch } from './adapters/http';
 
 // Mock the Todoist API
 vi.mock('@doist/todoist-sdk', () => {
@@ -124,5 +133,79 @@ describe('Todoist Reopener Worker', () => {
       ).toHaveBeenCalledTimes(1);
       // The scheduled handler catches errors, so it should not throw
     });
+  });
+});
+
+describe('customFetch adapter', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('should convert a successful Response to CustomFetchResponse', async () => {
+    const mockResponse = new Response('{"height":30}', {
+      status: 200,
+      statusText: 'OK',
+      headers: { 'content-type': 'application/json; charset=utf-8' },
+    });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse));
+
+    const result = await customFetch('https://api.example.com/data', {
+      method: 'GET',
+      timeout: 5000,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe(200);
+    expect(result.statusText).toBe('OK');
+    expect(result.headers['content-type']).toContain('application/json');
+    await expect(result.json()).resolves.toEqual({ height: 30 });
+  });
+
+  it('should strip the timeout option before calling native fetch', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(new Response('ok'));
+    vi.stubGlobal('fetch', fetchSpy);
+
+    await customFetch('https://api.example.com/data', {
+      method: 'POST',
+      timeout: 7000,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [, init] = fetchSpy.mock.calls[0];
+    expect(init).not.toHaveProperty('timeout');
+  });
+
+  it('should delegate text() to the response', async () => {
+    const mockResponse = new Response('hello world');
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse));
+
+    const result = await customFetch('https://api.example.com/data');
+
+    await expect(result.text()).resolves.toBe('hello world');
+  });
+
+  it('should delegate arrayBuffer() to the response', async () => {
+    const mockResponse = new Response('hello world');
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse));
+
+    const result = await customFetch('https://api.example.com/data');
+
+    const buffer = await result.arrayBuffer!();
+    expect(new TextDecoder().decode(buffer)).toBe('hello world');
+  });
+
+  it('should preserve non-ok status and statusText', async () => {
+    const mockResponse = new Response('Not found', {
+      status: 404,
+      statusText: 'Not Found',
+    });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse));
+
+    const result = await customFetch('https://api.example.com/missing');
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(404);
+    expect(result.statusText).toBe('Not Found');
+    await expect(result.text()).resolves.toBe('Not found');
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,5 @@
 import { SELF, env } from 'cloudflare:test';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { TodoistApi } from '@doist/todoist-sdk';
 
 // Mock the Todoist API
@@ -39,7 +39,7 @@ describe('Todoist Reopener Worker', () => {
 
     it('should execute scheduled job with valid token', async () => {
       (
-        TodoistApi.prototype.getCompletedTasksByCompletionDate as vi.Mock
+        TodoistApi.prototype.getCompletedTasksByCompletionDate as Mock
       ).mockResolvedValueOnce({
         items: [],
         nextCursor: null,
@@ -61,13 +61,13 @@ describe('Todoist Reopener Worker', () => {
       ];
 
       (
-        TodoistApi.prototype.getCompletedTasksByCompletionDate as vi.Mock
+        TodoistApi.prototype.getCompletedTasksByCompletionDate as Mock
       ).mockResolvedValueOnce({
         items: mockTasks,
         nextCursor: null,
       });
 
-      await SELF.scheduled();
+      await (SELF as unknown as { scheduled(): Promise<void> }).scheduled();
 
       expect(
         TodoistApi.prototype.getCompletedTasksByCompletionDate,
@@ -78,7 +78,7 @@ describe('Todoist Reopener Worker', () => {
     });
 
     it('should handle pagination correctly', async () => {
-      (TodoistApi.prototype.getCompletedTasksByCompletionDate as vi.Mock)
+      (TodoistApi.prototype.getCompletedTasksByCompletionDate as Mock)
         .mockResolvedValueOnce({
           items: [{ id: '1', content: 'Task 1' }],
           nextCursor: 'cursor-123',
@@ -88,12 +88,41 @@ describe('Todoist Reopener Worker', () => {
           nextCursor: null,
         });
 
-      await SELF.scheduled();
+      await (SELF as unknown as { scheduled(): Promise<void> }).scheduled();
 
       expect(
         TodoistApi.prototype.getCompletedTasksByCompletionDate,
       ).toHaveBeenCalledTimes(2);
       expect(TodoistApi.prototype.reopenTask).toHaveBeenCalledTimes(2);
+    });
+
+    it('should handle empty completed tasks list', async () => {
+      (
+        TodoistApi.prototype.getCompletedTasksByCompletionDate as Mock
+      ).mockResolvedValueOnce({
+        items: [],
+        nextCursor: null,
+      });
+
+      await (SELF as unknown as { scheduled(): Promise<void> }).scheduled();
+
+      expect(
+        TodoistApi.prototype.getCompletedTasksByCompletionDate,
+      ).toHaveBeenCalledTimes(1);
+      expect(TodoistApi.prototype.reopenTask).toHaveBeenCalledTimes(0);
+    });
+
+    it('should not crash when API throws an error', async () => {
+      (
+        TodoistApi.prototype.getCompletedTasksByCompletionDate as Mock
+      ).mockRejectedValueOnce(new Error('API request failed'));
+
+      await (SELF as unknown as { scheduled(): Promise<void> }).scheduled();
+
+      expect(
+        TodoistApi.prototype.getCompletedTasksByCompletionDate,
+      ).toHaveBeenCalledTimes(1);
+      // The scheduled handler catches errors, so it should not throw
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,28 +1,9 @@
 import {
   TodoistApi,
-  type CustomFetch,
   type Task,
   type GetCompletedTasksByCompletionDateArgs,
 } from '@doist/todoist-sdk';
-
-const customFetch: CustomFetch = async (url, options) => {
-  const init = { ...options };
-  delete init.timeout;
-  const response = await fetch(url, init);
-  const headers: Record<string, string> = {};
-  response.headers.forEach((value, key) => {
-    headers[key] = value;
-  });
-  return {
-    ok: response.ok,
-    status: response.status,
-    statusText: response.statusText,
-    headers,
-    text: () => response.text(),
-    json: () => response.json(),
-    arrayBuffer: () => response.arrayBuffer(),
-  };
-};
+import { customFetch } from './adapters/http';
 
 function timingSafeEqual(a: string, b: string): boolean {
   // While this leaks length information, it's a common practice and still

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,8 @@ import {
 } from '@doist/todoist-sdk';
 
 const customFetch: CustomFetch = async (url, options) => {
-  const { timeout: _ignored, ...init } = options ?? {};
+  const init = { ...options };
+  delete init.timeout;
   const response = await fetch(url, init);
   const headers: Record<string, string> = {};
   response.headers.forEach((value, key) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,8 @@
-import { TodoistApi, Task } from '@doist/todoist-sdk';
+import {
+  TodoistApi,
+  type Task,
+  type GetCompletedTasksByCompletionDateArgs,
+} from '@doist/todoist-sdk';
 
 function timingSafeEqual(a: string, b: string): boolean {
   // While this leaks length information, it's a common practice and still
@@ -84,7 +88,7 @@ export default {
           until: until.toISOString(),
           limit: 50, // Use the default limit
           cursor: cursor,
-        });
+        } satisfies GetCompletedTasksByCompletionDateArgs);
 
         allTasksToReopen.push(...response.items);
         cursor = response.nextCursor;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,27 @@
 import {
   TodoistApi,
+  type CustomFetch,
   type Task,
   type GetCompletedTasksByCompletionDateArgs,
 } from '@doist/todoist-sdk';
+
+const customFetch: CustomFetch = async (url, options) => {
+  const { timeout: _ignored, ...init } = options ?? {};
+  const response = await fetch(url, init);
+  const headers: Record<string, string> = {};
+  response.headers.forEach((value, key) => {
+    headers[key] = value;
+  });
+  return {
+    ok: response.ok,
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+    text: () => response.text(),
+    json: () => response.json(),
+    arrayBuffer: () => response.arrayBuffer(),
+  };
+};
 
 function timingSafeEqual(a: string, b: string): boolean {
   // While this leaks length information, it's a common practice and still
@@ -66,7 +85,9 @@ export default {
     console.log('Cron job started: Reopening tracked/routine Todoist tasks.');
 
     try {
-      const api = new TodoistApi(env.TODOIST_API_TOKEN);
+      const api = new TodoistApi(env.TODOIST_API_TOKEN, {
+        customFetch,
+      });
 
       const allTasksToReopen: Task[] = [];
       let cursor: string | null = null;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,8 +12,8 @@
     "skipLibCheck": true,
     "rootDir": "./src",
     "outDir": "dist",
-    "types": ["@cloudflare/workers-types", "@cloudflare/vitest-pool-workers"]
+    "types": ["@cloudflare/workers-types", "@cloudflare/vitest-pool-workers/types"]
   },
-  "include": ["src"],
+  "include": ["src", "worker-configuration.d.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,6 @@
     "outDir": "dist",
     "types": ["@cloudflare/workers-types", "@cloudflare/vitest-pool-workers"]
   },
-  "include": ["src", "tests", "vitest.config.ts"],
+  "include": ["src"],
   "exclude": ["node_modules", "dist"]
 }

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -1,0 +1,16 @@
+/**
+ * Environment bindings for the worker.
+ *
+ * Extends the global `Cloudflare.Env` interface (from `@cloudflare/workers-types`)
+ * with the worker's bindings. In line with the workers-types contract, these are
+ * merged into the `Env` type so `env.<BINDING>` is strongly typed.
+ *
+ * These bindings are configured as secrets/variables: see `.dev.vars` locally and
+ * `wrangler secret put` / Cloudflare dashboard for production.
+ */
+declare namespace Cloudflare {
+  interface Env {
+    TODOIST_API_TOKEN: string;
+    CRON_SECRET_TOKEN: string;
+  }
+}


### PR DESCRIPTION
The @doist/todoist-sdk v14.0.0 dynamically imports 'undici' (Node.js HTTP library) during fetch requests. When deployed to Cloudflare Worker with nodejs_compat enabled, process.versions.node is exposed, causing isNodeEnvironment() to return true and the SDK to attempt the undici import, which fails in the edge runtime. This produces runtime errors with httpStatusCode: undefined and responseData: undefined, breaking
the cron job execution.

This fix creates a CustomFetch adapter that wraps Workers' native fetch and converts the Response to SDK's CustomFetchResponse shape, bypassing the SDK's transport detection logic entirely. The adapter is passed to the TodoistApi constructor to ensure reliable API calls regardless of the compatibility flags.